### PR TITLE
template.js uses JQuery. Add dependency.

### DIFF
--- a/src/joomla.asset.json
+++ b/src/joomla.asset.json
@@ -43,7 +43,8 @@
       "type": "script",
       "uri": "template.js",
       "dependencies": [
-        "core"
+        "core",
+        "jquery"
       ]
     },
     {


### PR DESCRIPTION
On a site that uses protostar4 (see forum thread https://forum.joomla.de/thread/17293-hauptmenü-nicht-mehr-als-dropdown/?postID=121447) I saw in browser inspector the following message:

![grafik](https://user-images.githubusercontent.com/20780646/206878519-5be1ea7e-cd5d-4b56-bc6c-6919d4790910.png)

because JQuery is loaded too late (after template.js). Therefore I added dependency in joomla.asset.json to load JQuery before template.js.

On the other hand it's questionable if the current JQuery code in template.js is still needed in J!4. I don't know.